### PR TITLE
Rename prepare target to precommit

### DIFF
--- a/include/common.mk
+++ b/include/common.mk
@@ -65,11 +65,11 @@ test::
 .PHONY: lint
 lint::
 
-# prepare --- Perform tasks that need to be executed before committing.
+# precommit --- Perform tasks that need to be executed before committing.
 # Individual language Makefiles are expected to add additional recipies for this
 # target.
 .PHONY:
-prepare:: $(GENERATED_FILES) test lint
+precommit:: $(GENERATED_FILES) test lint
 
 # ci --- Perform tasks that need to be executed within a continuous integration
 # environment. Individual language Makefiles are expected to add additional


### PR DESCRIPTION
This PR will rename the `prepare` target to `precommit`. From memory of our voice discussions, you expressed a preference for `precommit` over `pre-commit`. Let me know if I misremembered that.

There will be a complimentary PR on `pkg-go` since it also defines a `prepare` target.

Closes make-files/issues#16.