### PR TITLE
Set MF_CI and MF_NON_INTERACTIVE variables

### DIFF
--- a/bin/ci-system-name
+++ b/bin/ci-system-name
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -n "${GITHUB_ACTION:-}" ]]; then
+    echo gha
+fi
+
+if [[ -n "${TRAVIS:-}" ]]; then
+    echo travisci
+fi
+
+if [[ -n "${CI:-}" ]]; then
+    echo generic
+fi

--- a/include/common.mk
+++ b/include/common.mk
@@ -2,6 +2,18 @@ export MF_PROJECT_ROOT := $(realpath $(dir $(word 1,$(MAKEFILE_LIST))))
 export MF_ROOT := $(MF_PROJECT_ROOT)/.makefiles
 export PATH := $(MF_ROOT)/lib/core/bin:$(PATH)
 
+# MF_CI is the name of any detected continuous integration system. If no CI
+# system is detected, MF_CI will be empty.
+export MF_CI ?= $(shell PATH="$(PATH)" ci-system-name)
+
+# MF_NON_INTERACTIVE will be non-empty when make is not running under an
+# interactive shell.
+ifeq ($(MF_CI),)
+export MF_NON_INTERACTIVE ?= $(shell [ -t 0 ] || echo true)
+else
+export MF_NON_INTERACTIVE ?= true
+endif
+
 # Run tests by default unless the project's main Makefile has already defined a
 # default goal.
 ifeq ($(.DEFAULT_GOAL),)

--- a/install.d/10.install-libraries
+++ b/install.d/10.install-libraries
@@ -2,10 +2,12 @@
 set -euo pipefail
 source "$MF_PROJECT_ROOT/.makefiles/lib/core/include/common.bash"
 
-if [[ -n "${TRAVIS:-}" ]]; then
+CI_SYSTEM="$(ci-system-name)"
+
+if [[ "$CI_SYSTEM" == travisci ]]; then
     install-lib travisci
 fi
 
-if [[ -n "${GITHUB_ACTION:-}" ]]; then
+if [[ "$CI_SYSTEM" == gha ]]; then
     install-lib gha
 fi


### PR DESCRIPTION
Relates to make-files/issues#23.

This PR introduces two new environment variables:

- `MF_CI` is the name of any detected CI system.
- `MF_NON_INTERACTIVE` indicates that `make` is running outside of an interactive shell.

A new Bash script is introduced to encapsulate the detection logic.

Things I need comments on:

- The choice of Makefile assignment operators.
- Whether `export` is appropriate. Basically, I want these available in Makefiles and sub-shells.