### PR TITLE
Add `GIT_HEAD_BRANCH` and use branch name in `GIT_HEAD_COMITTISH`.

### DIFF
--- a/include/common.mk
+++ b/include/common.mk
@@ -51,7 +51,7 @@ GIT_HEAD_TAG ?= $(if $(GIT_HEAD_BRANCH),,$(shell git describe --exact-match HEAD
 # GIT_HEAD_COMMITTISH is the "best" representation of the HEAD commit. If HEAD
 # is a branch or tag, this will be the branch or tag name. Otherwise it will be
 # the commit hash.
-GIT_HEAD_COMMITTISH	?= $(or $(GIT_HEAD_BRANCH),$(GIT_HEAD_TAG),$(GIT_HEAD_HASH))
+GIT_HEAD_COMMITTISH ?= $(or $(GIT_HEAD_BRANCH),$(GIT_HEAD_TAG),$(GIT_HEAD_HASH))
 
 # clean --- Removes all generated and ignored files. Individual language
 # Makefiles should also remove any build artifacts that aren't already ignored.

--- a/include/common.mk
+++ b/include/common.mk
@@ -44,9 +44,10 @@ GIT_HEAD_HASH ?= $(shell git rev-parse --short --verify HEAD)
 # detached (that is, no specific branch is checked out).
 GIT_HEAD_BRANCH ?= $(shell git symbolic-ref --short HEAD 2>/dev/null)
 
-# GIT_HEAD_BRANCH is the name of the current tag. It is empty if the HEAD is
-# not pointed to by a tag.
-GIT_HEAD_TAG ?= $(if $(GIT_HEAD_BRANCH),,$(shell git describe --exact-match HEAD 2>/dev/null))
+# GIT_HEAD_TAG is the name of the current tag. It is empty if the HEAD is not a
+# tag (either annotated, or un-annotated). If the HEAD commit is referred to by
+# multiple tags there is no guarantee which tag name will be used.
+GIT_HEAD_TAG ?= $(if $(GIT_HEAD_BRANCH),,$(shell git describe --tags --exact-match HEAD 2>/dev/null))
 
 # GIT_HEAD_COMMITTISH is the "best" representation of the HEAD commit. If HEAD
 # is a branch or tag, this will be the branch or tag name. Otherwise it will be

--- a/include/common.mk
+++ b/include/common.mk
@@ -36,10 +36,19 @@ CI_VERIFY_GENERATED_FILES ?= true
 
 # GET_HEAD_xxx variables containing information about the commit at the head of
 # the working tree.
-GIT_HEAD_HASH		?= $(shell git rev-parse --short --verify HEAD)
-GIT_HEAD_HASH_FULL	?= $(shell git rev-parse --verify HEAD)
-GIT_HEAD_TAG 		?= $(shell git describe --exact-match 2>/dev/null)
-GIT_HEAD_COMMITTISH	?= $(shell git describe --exact-match 2>/dev/null || git rev-parse --short --verify HEAD)
+GIT_HEAD_HASH_FULL	= $(shell git rev-parse --verify HEAD)
+GIT_HEAD_HASH		= $(shell git rev-parse --short --verify HEAD)
+GIT_HEAD_BRANCH		= $(shell git symbolic-ref --short HEAD 2>/dev/null)
+GIT_HEAD_COMMITTISH	= $(GIT_HEAD_HASH)
+
+ifneq ($(GIT_HEAD_BRANCH),)
+GIT_HEAD_COMMITTISH = $(GIT_HEAD_BRANCH)
+else
+GIT_HEAD_TAG		= $(shell git describe --exact-match HEAD 2>/dev/null)
+ifneq ($(GIT_HEAD_TAG),)
+GIT_HEAD_COMMITTISH = $(GIT_HEAD_TAG)
+endif
+endif
 
 # clean --- Removes all generated and ignored files. Individual language
 # Makefiles should also remove any build artifacts that aren't already ignored.

--- a/include/common.mk
+++ b/include/common.mk
@@ -34,10 +34,10 @@ GENERATED_FILES +=
 # the files in GENERATED_FILES are up-to-date.
 CI_VERIFY_GENERATED_FILES ?= true
 
-# GIT_HEAD_HASH is the full-length hash of the HEAD commit.
+# GIT_HEAD_HASH_FULL is the full-length hash of the HEAD commit.
 GIT_HEAD_HASH_FULL ?= $(shell git rev-parse --verify HEAD)
 
-# GIT_HEAD_HASH is the abbreviated (7-digit) hash of the HEAD commit.
+# GIT_HEAD_HASH is the abbreviated (7-character) hash of the HEAD commit.
 GIT_HEAD_HASH ?= $(shell git rev-parse --short --verify HEAD)
 
 # GIT_HEAD_BRANCH is the name of the current branch. It is empty if the HEAD is

--- a/include/common.mk
+++ b/include/common.mk
@@ -34,21 +34,24 @@ GENERATED_FILES +=
 # the files in GENERATED_FILES are up-to-date.
 CI_VERIFY_GENERATED_FILES ?= true
 
-# GET_HEAD_xxx variables containing information about the commit at the head of
-# the working tree.
-GIT_HEAD_HASH_FULL	= $(shell git rev-parse --verify HEAD)
-GIT_HEAD_HASH		= $(shell git rev-parse --short --verify HEAD)
-GIT_HEAD_BRANCH		= $(shell git symbolic-ref --short HEAD 2>/dev/null)
-GIT_HEAD_COMMITTISH	= $(GIT_HEAD_HASH)
+# GIT_HEAD_HASH is the full-length hash of the HEAD commit.
+GIT_HEAD_HASH_FULL ?= $(shell git rev-parse --verify HEAD)
 
-ifneq ($(GIT_HEAD_BRANCH),)
-GIT_HEAD_COMMITTISH = $(GIT_HEAD_BRANCH)
-else
-GIT_HEAD_TAG		= $(shell git describe --exact-match HEAD 2>/dev/null)
-ifneq ($(GIT_HEAD_TAG),)
-GIT_HEAD_COMMITTISH = $(GIT_HEAD_TAG)
-endif
-endif
+# GIT_HEAD_HASH is the abbreviated (7-digit) hash of the HEAD commit.
+GIT_HEAD_HASH ?= $(shell git rev-parse --short --verify HEAD)
+
+# GIT_HEAD_BRANCH is the name of the current branch. It is empty if the HEAD is
+# detached (that is, no specific branch is checked out).
+GIT_HEAD_BRANCH ?= $(shell git symbolic-ref --short HEAD 2>/dev/null)
+
+# GIT_HEAD_BRANCH is the name of the current tag. It is empty if the HEAD is
+# not pointed to by a tag.
+GIT_HEAD_TAG ?= $(if $(GIT_HEAD_BRANCH),,$(shell git describe --exact-match HEAD 2>/dev/null))
+
+# GIT_HEAD_COMMITTISH is the "best" representation of the HEAD commit. If HEAD
+# is a branch or tag, this will be the branch or tag name. Otherwise it will be
+# the commit hash.
+GIT_HEAD_COMMITTISH	?= $(or $(GIT_HEAD_BRANCH),$(GIT_HEAD_TAG),$(GIT_HEAD_HASH))
 
 # clean --- Removes all generated and ignored files. Individual language
 # Makefiles should also remove any build artifacts that aren't already ignored.


### PR DESCRIPTION
Fixes make-files/issues#21

```
❯ git switch master
M	Makefile
Your branch is up to date with 'origin/master'.
❯ make gitinfo
GIT_HEAD_HASH = 32d77ff
GIT_HEAD_HASH_FULL = 32d77ff7c0bb25cb120465377293931217a6cea0
GIT_HEAD_BRANCH = master
GIT_HEAD_TAG =
GIT_HEAD_COMMITTISH = master
```

```
❯ git switch --detach v0.6.3
M	Makefile
HEAD is now at 32d77ff Bump version to v0.6.3.
❯ make gitinfo
GIT_HEAD_HASH = 32d77ff
GIT_HEAD_HASH_FULL = 32d77ff7c0bb25cb120465377293931217a6cea0
GIT_HEAD_BRANCH =
GIT_HEAD_TAG = v0.6.3
GIT_HEAD_COMMITTISH = v0.6.3
```

```
❯ git switch --detach master~
M	Makefile
Previous HEAD position was 32d77ff Bump version to v0.6.3.
HEAD is now at 8dcde99 Change Dependabot schedule from weekly to daily.
❯ make gitinfo
GIT_HEAD_HASH = 8dcde99
GIT_HEAD_HASH_FULL = 8dcde998e6e0ede07cd32d2f9b467e9bdb56dbd7
GIT_HEAD_BRANCH =
GIT_HEAD_TAG =
GIT_HEAD_COMMITTISH = 8dcde99
```

Note also that `master` is at the same commit as the `v0.6.3` tag, and prior to this PR `GIT_HEAD_TAG` would contain the tag name even if it's the branch that is checked out. As of this PR `GIT_HEAD_TAG` is only populated when `HEAD` is actually the detached tag name.