### PR TITLE
Add `GIT_HEAD_SEMVER`.

### DIFF
--- a/bin/git-head-semver
+++ b/bin/git-head-semver
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+source "$(dirname ${BASH_SOURCE[0]})/../include/common.bash"
+
+if ! git symbolic-ref --short HEAD > /dev/null 2>&1; then
+    regex="^v?((0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(\\-[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?)$"
+    tag="$(git describe --exact-match HEAD 2>/dev/null)"
+
+    if [[ "$tag" =~ $regex ]]; then
+        echo ${BASH_REMATCH[1]}
+        exit 0
+    fi
+fi
+
+echo "0.0.0-$(git rev-parse --short --verify HEAD)"

--- a/include/common.mk
+++ b/include/common.mk
@@ -54,6 +54,13 @@ GIT_HEAD_TAG ?= $(if $(GIT_HEAD_BRANCH),,$(shell git describe --tags --exact-mat
 # the commit hash.
 GIT_HEAD_COMMITTISH ?= $(or $(GIT_HEAD_BRANCH),$(GIT_HEAD_TAG),$(GIT_HEAD_HASH))
 
+# GIT_HEAD_SEMVER is a semver representation of the HEAD commit. If GIT_HEAD_TAG
+# is a valid semver version (with an optional leading 'v') then GIT_HEAD_SEMVER
+# is that semver version (with the leading 'v' stripped, if present). Otherwise,
+# GIT_HEAD_SEMVER is a pre-release version formed from the commit hash, such as
+# "0.0.0-167aea9".
+GIT_HEAD_SEMVER ?= $(shell PATH="$(PATH)" git-head-semver)
+
 # clean --- Removes all generated and ignored files. Individual language
 # Makefiles should also remove any build artifacts that aren't already ignored.
 .PHONY: clean


### PR DESCRIPTION
Fixes make-files/issues#13, blocked by #5.

This PR introduces the `GIT_HEAD_SEMVER` variable, which contains a [semver](http://semver.org) compliant version string based on the current git head.

The logic is fairly simple: If the head is a tag that is already a valid semver version, the tag name is used unaltered. Otherwise, the semver version is `0.0.0-<commit hash>`.

As a concession to Go's requirement that tags have a leading `v`, any such leading `v` is stripped.