### PR TITLE
Refactor "make clean" to use git clean

### DIFF
--- a/include/common.mk
+++ b/include/common.mk
@@ -34,6 +34,10 @@ GENERATED_FILES +=
 # the files in GENERATED_FILES are up-to-date.
 CI_VERIFY_GENERATED_FILES ?= true
 
+# CLEAN_EXCLUSIONS is a space separated list of gitignore patterns to exclude
+# from being removed by "make clean".
+CLEAN_EXCLUSIONS +=
+
 # GIT_HEAD_HASH_FULL is the full-length hash of the HEAD commit.
 #
 # GIT_HEAD_HASH is the abbreviated (7-character) hash of the HEAD commit.
@@ -85,7 +89,8 @@ endif
 # global ignore configurations.
 .PHONY: clean-ignored
 clean-ignored::
-	git-find-ignored '*' | xargs -t -n1 rm -rf --
+	$(eval _EXCLUSION_ARGS := $(foreach EXCLUSION,$(CLEAN_EXCLUSIONS),--exclude "!$(EXCLUSION)"))
+	git -c core.excludesfile= clean -dX --force $(_EXCLUSION_ARGS)
 
 # regenerate --- Removes and regenerates all files in the GENERATED_FILES list.
 .PHONY: regenerate


### PR DESCRIPTION
This PR will change the commands used by `make clean` from relying on `git-find-ignored` to a single invocation of `git clean`.

The strategy will become:
- Use a top level [`-c`](https://git-scm.com/docs/git#Documentation/git.txt--cltnamegtltvaluegt) option to un-set Git's `core.excludesfile` config option, to temporarily disable global ignore rules
- Use the [`-d`](https://git-scm.com/docs/git-clean#Documentation/git-clean.txt--d) flag to remove directories
- Use the [`-X`](https://git-scm.com/docs/git-clean#Documentation/git-clean.txt--X) flag to remove **only** ignored files
- Use the -[`--force`](https://git-scm.com/docs/git-clean#Documentation/git-clean.txt---force) flag so that Git actually proceeds with the removal
- Introduce a `CLEAN_EXCLUSIONS` variable, which will be used to build a list of [`--exclude`](https://git-scm.com/docs/git-clean#Documentation/git-clean.txt---excludeltpatterngt) options, allowing packages to exclude things from `make clean` in a simple manner

Note that when building the exclusions list, each `CLEAN_EXCLUSIONS` pattern will be negated by prefixing with a `!`, which effectively "un-ignores" whatever is matched. This works because the `git clean` command is only removing *ignored* files. It's a kind of double-negative effect.

An example of usage might be:

```Makefile
# Ensure that dependencies are not removed by "make clean".
CLEAN_EXCLUSIONS += /node_modules/ /yarn.lock
```

Relates to make-files/issues#14.