### PR TITLE
Remove non-operational sercondary expansion of `GENERATED_FILES`.

### DIFF
--- a/include/common.mk
+++ b/include/common.mk
@@ -124,7 +124,7 @@ lint::
 # Individual language Makefiles are expected to add additional recipies for this
 # target.
 .PHONY: precommit
-precommit:: $(GENERATED_FILES)
+precommit:: $$(GENERATED_FILES)
 
 # ci --- Perform tasks that need to be executed within a continuous integration
 # environment. Individual language Makefiles are expected to add additional

--- a/include/common.mk
+++ b/include/common.mk
@@ -100,7 +100,7 @@ clean-ignored::
 
 # generate --- Builds any out-of-date files in the GENERATED_FILES list.
 .PHONY: generate
-generate: $(GENERATED_FILES)
+generate:: $$(GENERATED_FILES)
 
 # regenerate --- Removes and regenerates all files in the GENERATED_FILES list.
 .PHONY: regenerate

--- a/include/common.mk
+++ b/include/common.mk
@@ -108,6 +108,16 @@ regenerate::
 	$(MAKE) --no-print-directory clean-generated
 	$(MAKE) --no-print-directory generate
 
+# verify-generated --- Removes and regenerates all files in the GENERATED_FILES
+# list and checks for differences to the committed files. The target fails if
+# differences are detected.
+.PHONY: verify-generated _verify-generated
+verify-generated: $$(if $$(GENERATED_FILES),_verify-generated,)
+_verify-generated:
+	@echo "--- checking for out-of-date generated files"
+	@$(MAKE) --no-print-directory regenerate
+	@git diff --exit-code -- $(GENERATED_FILES)
+
 # test --- Executes all tests.
 # Individual language Makefiles are expected to add additional recipies for this
 # target.
@@ -132,10 +142,5 @@ precommit:: $$(GENERATED_FILES)
 .PHONY: ci
 ci::
 ifneq ($(CI_VERIFY_GENERATED_FILES),)
-ifneq ($$(GENERATED_FILES),)
-	@echo "--- checking for out-of-date generated files"
-	@$(MAKE) --no-print-directory regenerate
-	@git diff -- $(GENERATED_FILES)
-	@!(git status --porcelain -- $(GENERATED_FILES) | grep .)
-endif
+ci:: verify-generated
 endif


### PR DESCRIPTION
(likely) Fixes make-files/issues#37

This PR removes all conditionals around the use of `GENERATED_FILES`, as they were not functioning correctly. We expect the use of `$$GENERATED_FILES` was being evaluated in the first pass to the string `"$GENERATED_FILES"`, or something like that.

These conditionals were present to ensure the correct behavior when `GENERATED_FILES` is empty.

I have removed unnecessary conditionals around recursive make calls and `rm -f` which is a no-op if given an empty file list.

Finally, to avoid invoking recursive make with an empty `GENERATED_FILES` list, which would execute the default target instead, I have added a new `generate` target, which rebuilds any outdated generated files simply by listning them as prerequisites. This allows `regenerate` to run `clean-generated` then `generate` in order without having to deal with any empty lists.