### PR TITLE
Suppress stderr output from which under Linux

### DIFF
--- a/include/common.bash
+++ b/include/common.bash
@@ -21,6 +21,6 @@ fi
 
 MF_VERSION="1"
 
-if [[ "$(which build-resource)" != "$MF_ROOT/lib/core/bin/build-resource" ]]; then
+if [[ "$(which build-resource 2>/dev/null)" != "$MF_ROOT/lib/core/bin/build-resource" ]]; then
     PATH="$MF_ROOT/lib/core/bin:$PATH"
 fi


### PR DESCRIPTION
Under Linux, the makefiles currently spew a bunch of warnings from `which`:

```
$ make
curl -sfL https://makefiles.dev/v1 | bash /dev/stdin ".makefiles/Makefile"
which: no build-resource in (/home/username/.nvm/versions/node/v12.18.3/bin:/home/username/bin:/home/username/go/bin:/home/username/.local/bin:/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/var/lib/flatpak/exports/bin:/usr/lib/jvm/default/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl:/var/lib/snapd/snap/bin:/home/username/go/bin:/home/username/pear/bin:/home/username/.gem/ruby/2.7.0/bin:/home/username/bin:/home/username/.local/bin:~/.composer/vendor/bin:/opt/depot_tools)
--- executing core library installation hooks
which: no build-resource in (/home/username/.nvm/versions/node/v12.18.3/bin:/home/username/bin:/home/username/go/bin:/home/username/.local/bin:/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/var/lib/flatpak/exports/bin:/usr/lib/jvm/default/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl:/var/lib/snapd/snap/bin:/home/username/go/bin:/home/username/pear/bin:/home/username/.gem/ruby/2.7.0/bin:/home/username/bin:/home/username/.local/bin:~/.composer/vendor/bin:/opt/depot_tools)
which: no build-resource in (/home/username/.nvm/versions/node/v12.18.3/bin:/home/username/bin:/home/username/go/bin:/home/username/.local/bin:/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/var/lib/flatpak/exports/bin:/usr/lib/jvm/default/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl:/var/lib/snapd/snap/bin:/home/username/go/bin:/home/username/pear/bin:/home/username/.gem/ruby/2.7.0/bin:/home/username/bin:/home/username/.local/bin:~/.composer/vendor/bin:/opt/depot_tools)
which: no cwx-build-resource in (/home/username/Work/github.cwx.io/overpass/overpass-js/.makefiles/lib/core/bin:/home/username/.nvm/versions/node/v12.18.3/bin:/home/username/bin:/home/username/go/bin:/home/username/.local/bin:/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/var/lib/flatpak/exports/bin:/usr/lib/jvm/default/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl:/var/lib/snapd/snap/bin:/home/username/go/bin:/home/username/pear/bin:/home/username/.gem/ruby/2.7.0/bin:/home/username/bin:/home/username/.local/bin:~/.composer/vendor/bin:/opt/depot_tools)
--- [cwx] executing core library installation hooks
which: no build-resource in (/home/username/.nvm/versions/node/v12.18.3/bin:/home/username/bin:/home/username/go/bin:/home/username/.local/bin:/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/var/lib/flatpak/exports/bin:/usr/lib/jvm/default/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl:/var/lib/snapd/snap/bin:/home/username/go/bin:/home/username/pear/bin:/home/username/.gem/ruby/2.7.0/bin:/home/username/bin:/home/username/.local/bin:~/.composer/vendor/bin:/opt/depot_tools)
which: no cwx-build-resource in (/home/username/Work/github.cwx.io/overpass/overpass-js/.makefiles/lib/core/bin:/home/username/.nvm/versions/node/v12.18.3/bin:/home/username/bin:/home/username/go/bin:/home/username/.local/bin:/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/var/lib/flatpak/exports/bin:/usr/lib/jvm/default/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl:/var/lib/snapd/snap/bin:/home/username/go/bin:/home/username/pear/bin:/home/username/.gem/ruby/2.7.0/bin:/home/username/bin:/home/username/.local/bin:~/.composer/vendor/bin:/opt/depot_tools)
--- [cwx] fetching pkg-js/v1 archive
--- [cwx] added pkg-js/v1 archive to the cache
--- [cwx] unpacking js@v1 package archive
--- [cwx] executing js@v1 package install hooks
curl -sfL https://makefiles.dev/v1 | bash /dev/stdin ".makefiles/pkg/js/v1/with-yarn.mk"
which: no build-resource in (/home/username/.nvm/versions/node/v12.18.3/bin:/home/username/bin:/home/username/go/bin:/home/username/.local/bin:/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/var/lib/flatpak/exports/bin:/usr/lib/jvm/default/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl:/var/lib/snapd/snap/bin:/home/username/go/bin:/home/username/pear/bin:/home/username/.gem/ruby/2.7.0/bin:/home/username/bin:/home/username/.local/bin:~/.composer/vendor/bin:/opt/depot_tools)
--- fetching make-files/pkg-js@v1 repository archive
--- added make-files/pkg-js@v1 repository archive to the cache
--- unpacking js@v1 package archive
curl -sfL https://makefiles.dev/v1 | bash /dev/stdin ".makefiles/pkg/js/v1/Makefile"
which: no build-resource in (/home/username/.nvm/versions/node/v12.18.3/bin:/home/username/bin:/home/username/go/bin:/home/username/.local/bin:/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/var/lib/flatpak/exports/bin:/usr/lib/jvm/default/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl:/var/lib/snapd/snap/bin:/home/username/go/bin:/home/username/pear/bin:/home/username/.gem/ruby/2.7.0/bin:/home/username/bin:/home/username/.local/bin:~/.composer/vendor/bin:/opt/depot_tools)
which: no build-resource in (/home/username/.nvm/versions/node/v12.18.3/bin:/home/username/bin:/home/username/go/bin:/home/username/.local/bin:/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/var/lib/flatpak/exports/bin:/usr/lib/jvm/default/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl:/var/lib/snapd/snap/bin:/home/username/go/bin:/home/username/pear/bin:/home/username/.gem/ruby/2.7.0/bin:/home/username/bin:/home/username/.local/bin:~/.composer/vendor/bin:/opt/depot_tools)
which: no cwx-build-resource in (/home/username/Work/github.cwx.io/overpass/overpass-js/.makefiles/lib/core/bin:/home/username/.nvm/versions/node/v12.18.3/bin:/home/username/bin:/home/username/go/bin:/home/username/.local/bin:/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/var/lib/flatpak/exports/bin:/usr/lib/jvm/default/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl:/var/lib/snapd/snap/bin:/home/username/go/bin:/home/username/pear/bin:/home/username/.gem/ruby/2.7.0/bin:/home/username/bin:/home/username/.local/bin:~/.composer/vendor/bin:/opt/depot_tools)
```

This PR fixes the issue by suppressing stderr when using `which` in a conditional.