### PR TITLE
Expose GIT_HEAD_TAG variable

### DIFF
--- a/bin/generate-git-include
+++ b/bin/generate-git-include
@@ -7,6 +7,7 @@ source "$(dirname ${BASH_SOURCE[0]})/../include/common.bash"
 GIT_HEAD_HASH_FULL="$(git rev-parse --verify HEAD)"
 GIT_HEAD_HASH="$(git rev-parse --short --verify HEAD)"
 GIT_HEAD_BRANCH="$(git symbolic-ref --short HEAD 2>/dev/null || true)"
+GIT_HEAD_TAG=
 GIT_HEAD_COMMITTISH="$GIT_HEAD_HASH"
 
 GIT_HEAD_SEMVER="0.0.0-$GIT_HEAD_HASH"
@@ -48,6 +49,7 @@ echo
 echo "GIT_HEAD_HASH_FULL ?= $GIT_HEAD_HASH_FULL"
 echo "GIT_HEAD_HASH ?= $GIT_HEAD_HASH"
 echo "GIT_HEAD_BRANCH ?= $GIT_HEAD_BRANCH"
+echo "GIT_HEAD_TAG ?= $GIT_HEAD_TAG"
 echo "GIT_HEAD_COMMITTISH ?= $GIT_HEAD_COMMITTISH"
 echo "GIT_HEAD_SEMVER ?= $GIT_HEAD_SEMVER"
 echo "GIT_HEAD_SEMVER_MAJOR ?= $GIT_HEAD_SEMVER_MAJOR"

--- a/include/common.mk
+++ b/include/common.mk
@@ -45,9 +45,10 @@ CLEAN_EXCLUSIONS +=
 # GIT_HEAD_BRANCH is the name of the current branch. It is empty if the HEAD is
 # detached (that is, no specific branch is checked out).
 #
-# GIT_HEAD_TAG is the name of the current tag. It is empty if the HEAD is not a
-# tag (either annotated, or un-annotated). If the HEAD commit is referred to by
-# multiple tags there is no guarantee which tag name will be used.
+# GIT_HEAD_TAG is the name of the current tag. It is empty if the HEAD is not
+# detached, or if the HEAD is not a tag (either annotated, or un-annotated). If
+# the HEAD commit is referred to by multiple tags there is no guarantee which
+# tag name will be used.
 #
 # GIT_HEAD_COMMITTISH is the "best" representation of the HEAD commit. If HEAD
 # is a branch or tag, this will be the branch or tag name. Otherwise it will be


### PR DESCRIPTION
I've also added a caveat about GIT_HEAD_TAG only working while the repo is in "detached HEAD" state. This is important, because otherwise a CI build for a branch that also happens to be a tag might be treated like a tag build.