### PR TITLE
Fix git-find errors when the file list is empty

### DIFF
--- a/bin/git-find
+++ b/bin/git-find
@@ -14,4 +14,4 @@ fi
 cd "$MF_PROJECT_ROOT"
 files="$(git ls-files; git ls-files --other --exclude-standard)"
 files="$(find $files 2>/dev/null || true)"
-find $files -type f -iname "$1"
+[[ -n "$files" ]] && find $files -type f -iname "$1"


### PR DESCRIPTION
On some occasions I've noticed the Makefiles producing errors like this:

```
find: illegal option -- t
usage: find [-H | -L | -P] [-EXdsx] [-f path] path ... [expression]
       find [-H | -L | -P] [-EXdsx] -f path [path ...] [expression]
```

After some digging, I found that this error was coming from `git-find`. In some edge cases the list of files being passed to `find` could be empty, which leads to the above error. Still not 100% sure of the exact cause for an empty file list.

This PR fixes the issue by only running `find` if the list of files is non-empty.